### PR TITLE
dedupe handling of errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "canhaveinternet"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-std 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prometheus 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canhaveinternet"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Mike Moran <mike@houseofmoran.com>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,40 @@ use tide;
 
 type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+fn handle_success(
+    response: surf::Response,
+    start: SystemTime,
+    elapsed: Duration,
+    successful_request_histogram: Histogram,
+) -> Result<(), GenericError> {
+    println!(
+        "status = {:?}, start = {:?}, elapsed = {:?}",
+        response.status(),
+        start.duration_since(SystemTime::UNIX_EPOCH)?,
+        elapsed
+    );
+    successful_request_histogram.observe(elapsed.as_millis() as f64);
+
+    Ok(())
+}
+
+fn handle_error(
+    error: GenericError,
+    start: SystemTime,
+    elapsed: Duration,
+    failed_request_histogram: Histogram,
+) -> Result<(), GenericError> {
+    println!(
+        "error = {:?}, start = {:?}, elapsed = {:?}",
+        error,
+        start.duration_since(SystemTime::UNIX_EPOCH)?,
+        elapsed
+    );
+    failed_request_histogram.observe(elapsed.as_millis() as f64);
+
+    Ok(())
+}
+
 async fn check(
     successful_request_histogram: Histogram,
     failed_request_histogram: Histogram,
@@ -15,37 +49,19 @@ async fn check(
     let timeout = Duration::from_millis(5000);
 
     let start = SystemTime::now();
-    let response = future::timeout(timeout, surf::get(url)).await;
-    let elapsed = start.elapsed()?;
-    match response {
-        Result::Ok(surf_response) => match surf_response {
+    let timed_result = future::timeout(timeout, surf::get(url)).await;
+    let elapsed = start.elapsed().unwrap();
+    match timed_result {
+        Result::Ok(surf_result) => match surf_result {
             Result::Ok(response) => {
-                println!(
-                    "status = {:?}, start = {:?}, elapsed = {:?}",
-                    response.status(),
-                    start.duration_since(SystemTime::UNIX_EPOCH)?,
-                    elapsed
-                );
-                successful_request_histogram.observe(elapsed.as_millis() as f64);
+                handle_success(response, start, elapsed, successful_request_histogram)?;
             }
-            Result::Err(error) => {
-                println!(
-                    "error = {:?}, start = {:?}, elapsed = {:?}",
-                    error,
-                    start.duration_since(SystemTime::UNIX_EPOCH)?,
-                    elapsed
-                );
-                failed_request_histogram.observe(elapsed.as_millis() as f64);
+            Result::Err(e) => {
+                handle_error(e, start, elapsed, failed_request_histogram)?;
             }
         },
-        Result::Err(error) => {
-            println!(
-                "error = {:?}, start = {:?}, elapsed = {:?}",
-                error,
-                start.duration_since(SystemTime::UNIX_EPOCH)?,
-                elapsed
-            );
-            failed_request_histogram.observe(elapsed.as_millis() as f64);
+        Result::Err(e) => {
+            handle_error(Box::new(e), start, elapsed, failed_request_histogram)?;
         }
     }
 


### PR DESCRIPTION
- bump patch version
- extract separate error handling and success functions
- use Boxed TimeoutError so that it can be handled
  generically
- tidy-up names
- consistently map clock-skew error to a Result